### PR TITLE
coarchi integration via command + new "$.fs.cleanFolder" function

### DIFF
--- a/com.archimatetool.script.commandline/LICENSE.txt
+++ b/com.archimatetool.script.commandline/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2021 Phillip Beauvoir & Jean-Baptiste Sarrodie
+Copyright (c) 2017-2022 Phillip Beauvoir & Jean-Baptiste Sarrodie
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/com.archimatetool.script.feature/LICENSE.txt
+++ b/com.archimatetool.script.feature/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2021 Phillip Beauvoir & Jean-Baptiste Sarrodie
+Copyright (c) 2017-2022 Phillip Beauvoir & Jean-Baptiste Sarrodie
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/com.archimatetool.script.groovy/LICENSE.txt
+++ b/com.archimatetool.script.groovy/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2021 Phillip Beauvoir & Jean-Baptiste Sarrodie
+Copyright (c) 2017-2022 Phillip Beauvoir & Jean-Baptiste Sarrodie
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/com.archimatetool.script.jruby/LICENSE.txt
+++ b/com.archimatetool.script.jruby/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2021 Phillip Beauvoir & Jean-Baptiste Sarrodie
+Copyright (c) 2017-2022 Phillip Beauvoir & Jean-Baptiste Sarrodie
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/com.archimatetool.script.tests/LICENSE.txt
+++ b/com.archimatetool.script.tests/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2021 Phillip Beauvoir & Jean-Baptiste Sarrodie
+Copyright (c) 2017-2022 Phillip Beauvoir & Jean-Baptiste Sarrodie
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/com.archimatetool.script/LICENSE.txt
+++ b/com.archimatetool.script/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2021 Phillip Beauvoir & Jean-Baptiste Sarrodie
+Copyright (c) 2017-2022 Phillip Beauvoir & Jean-Baptiste Sarrodie
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/com.archimatetool.script/META-INF/MANIFEST.MF
+++ b/com.archimatetool.script/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Archi Scripting (jArchi)
 Bundle-SymbolicName: com.archimatetool.script;singleton:=true
 Bundle-Localization: plugin
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-Vendor: Phillip Beauvoir & Jean-Baptiste Sarrodie
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui,

--- a/com.archimatetool.script/plugin.properties
+++ b/com.archimatetool.script/plugin.properties
@@ -7,3 +7,5 @@ view.name.0 = Scripts Console
 page.name = Scripting
 command.name.0 = Toggle Scripts Console
 command.label.0 = Scripts Console
+command.name.1 = Run Script
+command.label.1 = Run Script

--- a/com.archimatetool.script/plugin.xml
+++ b/com.archimatetool.script/plugin.xml
@@ -15,6 +15,16 @@
             id="com.archimatetool.scripts.command.showScriptsConsole"
             name="%command.name.0">
       </command>
+      <command
+            defaultHandler="com.archimatetool.script.RunScriptHandler"
+            id="com.archimatetool.scripts.command.runScript"
+            name="%command.name.1">
+         <commandParameter
+               id="com.archimatetool.scripts.command.runScript.param1"
+               name="scriptfile"
+               optional="false">
+         </commandParameter>
+      </command>
    </extension>
    <extension
          point="org.eclipse.ui.menus">

--- a/com.archimatetool.script/src/com/archimatetool/script/RunScriptHandler.java
+++ b/com.archimatetool.script/src/com/archimatetool/script/RunScriptHandler.java
@@ -1,0 +1,45 @@
+/**
+ * This program and the accompanying materials
+ * are made available under the terms of the License
+ * which accompanies this distribution in the file LICENSE.txt
+ */
+package com.archimatetool.script;
+
+import java.io.File;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.jface.dialogs.MessageDialog;
+
+import com.archimatetool.editor.ui.services.ViewManager;
+import com.archimatetool.script.views.console.ConsoleView;
+import com.archimatetool.script.views.scripts.Messages;
+
+/**
+ * Show Scripts View
+ * 
+ * @author Phillip Beauvoir
+ */
+public class RunScriptHandler extends AbstractHandler {
+
+    @Override
+    public Object execute(ExecutionEvent event) throws ExecutionException {
+        ViewManager.showViewPart(ConsoleView.ID, false);
+        String scriptName = event.getParameter("com.archimatetool.scripts.command.runScript.param1");
+        if (scriptName.isEmpty()) {
+        	return null;
+        }
+        try {
+            File fFile = new File(ArchiScriptPlugin.INSTANCE.getUserScriptsFolder(), scriptName);
+            RunArchiScript runner = new RunArchiScript(fFile);
+            runner.run();
+        }
+        catch(Exception ex) {
+            MessageDialog.openError(null, Messages.RunScriptAction_1, ex.getMessage());
+        }
+        return null;
+    }
+
+
+}

--- a/com.archimatetool.script/src/com/archimatetool/script/dom/jarchi/FS.java
+++ b/com.archimatetool.script/src/com/archimatetool/script/dom/jarchi/FS.java
@@ -9,7 +9,12 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Base64;
+import java.util.Comparator;
+
+import com.archimatetool.script.dom.model.CurrentModel;
 
 /**
  * File services
@@ -72,4 +77,54 @@ public class FS {
         File parent = file.getParentFile();
         return parent != null ? parent.mkdirs() : false;
     }
+    
+    /**
+     * Removes all files from folder
+     * @param path
+     * @throws IOException
+     */
+    public void cleanFolder(String path) throws IOException {
+    	CurrentModel model = new CurrentModel();
+    	File file = new File(model.getPath()); // /<base>/.git/temp.archimate
+    	File gitpath = file.getParentFile(); // /<base>/.git/
+    	File base = gitpath.getParentFile(); // /<base>/.git/
+    	File folder = new File(path);
+    	if (folder.isDirectory() && isSubDirectory(base, folder) && !isSubDirectory(gitpath, folder)) {
+	    	Path pathToBeDeleted = Path.of(path);
+	
+	    	Files.walk(pathToBeDeleted)
+		        .sorted(Comparator.reverseOrder())
+		        .map(Path::toFile)
+		        .forEach(File::delete);
+    	} else {
+    		System.err.println("Could not empty folder '" + path +"', not a directory or sub-directory of '"+ base.toString()+"'");
+    		//throw new IOException("Could not empty folder '" + path +"', not a directory or sub-directory of '"+ base.toString()+"'");
+    	}
+    	
+    }
+    
+    /**
+     * Checks, whether the child directory is a subdirectory of the base 
+     * directory.
+     *
+     * @param base the base directory.
+     * @param child the suspected child directory.
+     * @return true, if the child is a subdirectory of the base directory.
+     * @throws IOException if an IOError occured during the test.
+     */
+    private boolean isSubDirectory(File base, File child)
+        throws IOException {
+        base = base.getCanonicalFile();
+        child = child.getCanonicalFile();
+
+        File parentFile = child;
+        while (parentFile != null) {
+            if (base.equals(parentFile)) {
+                return true;
+            }
+            parentFile = parentFile.getParentFile();
+        }
+        return false;
+    }
+    
 }


### PR DESCRIPTION
Hi @Phillipus,

This pull request is a following up my question in archimatetool/archi-scripting-plugin#77 (comment)

> Btw, I am planning to use this feature when a user publishes a Change via the "coArchi" Plugin to the git Repo. Is there some way of "event hook" for "before commit" or "after push" to hook into this workflow with a jArchi script?
> 
> Thanks in advance!

For realizing my envisioned Archi workflow it prepared this pull request since there is currently no integration of jArchi & coArchi.

This pull-request realizes the following:

- Add support for jArchi RunScriptHandler via Command
- Add "$.fs.cleanFolder" function for cleaning a folder under the git workdirectory (e.g. "Views")

As an example how i use this new integration between jArchi & coArchi is the following jArchi script `ExportSVG.ajs`:

```javascript
/*
 * JArchi Script "Export SVG & PNG pre-commit"
 */

console.clear();
console.log("Export all views as PNG [pre-commit]...");
console.log($('archimate-diagram-model').first());

function getFolderStruct(o, delim) {
	var folder_struct = '';
	$('#'+o.id).parents().each(function(p) {
		if (p.type == 'folder') {
			folder_struct = p.name.replaceAll(" ","-") + delim + folder_struct;
		}
	});
	console.log(folder_struct);
	return folder_struct;
}

function getFolderRoot(o) {
  var svgpath = false;
  var rootpath = o.model.getPath();
  var delim = "";
  if (rootpath.indexOf("/.git/temp.archimate") !== -1) {
    delim = "/";
    svgpath = rootpath.replace("/.git/temp.archimate", "/");
  } else if (rootpath.indexOf("\\.git\\temp.archimate") !== -1) {
    delim = "\\";
    svgpath = rootpath.replace("\\.git\\temp.archimate", "\\");
  }
  return svgpath;
}

function emptyFolder() {
  var model = $('archimate-diagram-model').first();
  var root = getFolderRoot(model)
  if (root != false) {
    var delim = root.charAt(root.length-1);
    console.log("delim", delim);
    console.log("Empty folder", root);
    $.fs.cleanFolder(root + "Views")
  }
}

emptyFolder();

$('archimate-diagram-model').each(function(o) {
  console.log("Exporting " + o.name + " ...");
  var svgpath = getFolderRoot(o);
  var delim = svgpath.charAt(svgpath.length-1);
  var filepath = getFolderStruct(o, delim);
  var filename = o.name.replaceAll(" ","-");
  svgpath += filepath + filename;

  console.log(" to " + svgpath  + ".png");
  if (svgpath) {
    $.model.renderViewToSVG(o, svgpath + ".svg", true);
    $.model.renderViewToFile(o, svgpath + ".png", "PNG", {scale: 1, margin: 20});
  }
});
```

In my workflow I use the pre-commit coArchi integration from my pull-request: https://github.com/archimatetool/archi-modelrepository-plugin/pull/183 and i configured `ExportSVG` as script name:
![image](https://user-images.githubusercontent.com/88032369/145792339-9f022562-e117-4969-b04b-90256ff0fcf1.png)

